### PR TITLE
Modified Regex

### DIFF
--- a/lib/ntlm.js
+++ b/lib/ntlm.js
@@ -227,7 +227,7 @@ exports.challengeHeader = function (hostname, domain) {
 };
 
 exports.responseHeader = function (res, url, domain, username, password) {
-  var serverNonce = new Buffer((res.headers['www-authenticate'].match(/^NTLM\s+(.+?)(,|\s+)/) || [])[1], 'base64');
+  var serverNonce = new Buffer((res.headers['www-authenticate'].match(/^NTLM\s+(.+?)(,|\s+|$)/) || [])[1], 'base64');
   var hostname = require('url').parse(url).hostname;
   return 'NTLM ' + exports.encodeType3(username, hostname, domain, exports.decodeType2(serverNonce), password).toString('base64')
 };


### PR DESCRIPTION
If there was no comma or whitespace at the end of www-authenticate, this would fail to match. Added EOL to the list.
